### PR TITLE
test_modules: add tcp module

### DIFF
--- a/srv/test_modules/__init__.py
+++ b/srv/test_modules/__init__.py
@@ -1,11 +1,13 @@
 from . import ping
 from . import httpt
 from . import ssvplwc
+from . import tcpt
 
 modules = {
     "ping": ping.ping_t,
     "http": httpt.http_t,
-    "ssvplwc": ssvplwc.ssvplwc_t
+    "ssvplwc": ssvplwc.ssvplwc_t,
+    "tcp": tcpt.tcp_t
 }
 
 

--- a/srv/test_modules/httpt.py
+++ b/srv/test_modules/httpt.py
@@ -1,3 +1,25 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# ssvp: server statistics viewer project
+# Copyright (C) 2023 Amy Parker <amy@amyip.net>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA or visit the
+# GNU Project at https://gnu.org/licenses. The GNU Affero General Public
+# License version 3 is available at, for your convenience,
+# https://www.gnu.org/licenses/agpl-3.0.en.html.
+
 import requests
 
 methods = {

--- a/srv/test_modules/ping.py
+++ b/srv/test_modules/ping.py
@@ -1,3 +1,25 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# ssvp: server statistics viewer project
+# Copyright (C) 2023 Amy Parker <amy@amyip.net>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA or visit the
+# GNU Project at https://gnu.org/licenses. The GNU Affero General Public
+# License version 3 is available at, for your convenience,
+# https://www.gnu.org/licenses/agpl-3.0.en.html.
+
 import ping3
 
 

--- a/srv/test_modules/tcpt.py
+++ b/srv/test_modules/tcpt.py
@@ -23,11 +23,11 @@
 import socket
 
 
-def ssvplwc_t(srv: dict) -> bool:
+def tcp_t(srv: dict) -> bool:
+    ss = socket.socket()
     try:
-        ss = socket.socket()
         ss.connect((srv["ip"], int(srv["args"])))
-        b = ss.recv(2048)
-        return b == b"ssvp-ok"
-    except ConnectionError:
+        ss.close()
+        return True
+    except ConnectionRefusedError:
         return False


### PR DESCRIPTION
This patch adds the TCP module. In experimentation, it was determined a UDP module is impossible.

Signed-off-by: Amy Parker <amy@amyip.net>