### PR TITLE
app: add ssl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ ssvp-config.json
 *.js
 *.db
 target/
+*.pem

--- a/README.md
+++ b/README.md
@@ -31,6 +31,26 @@ A more streamlined way to install SSVP is currently in development. Until then, 
 6. Add a runner for `srv/interval.py` to run on intervals (ideally every 1-5 minutes) in your crontab.
 7. Launch `srv/app.py` in a persistent environment (such as tmux).
 
+## Configuration
+
+### SSL
+
+There are three options for SSL (when directly running):
+
+1. **No SSL**: set ssl to `null`
+2. **Self-signed Certificate**: set ssl to `"adhoc"`
+3. **Existing Certificate**: set ssl to `["/path/to/cert.pem", "/path/to/key.pem"]`
+
+> To learn how to generate a widely-accepted certificate, visit [EFF Certbot](https://certbot.eff.org/instructions).
+> You should select "other" when selecting the server software if running directly.
+> Please note that we don't recommend using Certbot via snapd, check if your package manager has a native certbot package.
+
+### Ports
+
+You should specify the port for SSVP to run on. If you don't specify a port, it'll run on 80 (non-ssl) or 443 (ssl).
+
+> We don't currently support an http-redirect-to-https implementation, use a reverse proxy for that functionality.
+
 ## Contributing
 
 There are two main ways you can help contribute to SSVP:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ mysql-connector-python
 ping3
 requests
 psycopg2
+pyopenssl

--- a/srv/app.py
+++ b/srv/app.py
@@ -74,4 +74,6 @@ def api_v1_uptime(srv: str):
 
 # If not run using `flask run`, we can pull options from the config file
 if __name__ == "__main__":
-    app.run(host="::" if config["enable_host_ipv6"] else "0.0.0.0", port=config["port"])
+    app.run(host="::" if config["enable_host_ipv6"] else "0.0.0.0",
+            port=config["port"] if "port" in config else (80 if config["ssl"] is None else 443),
+            ssl_context=tuple(config["ssl"]) if type(config["ssl"]) is list else config["ssl"])


### PR DESCRIPTION
This patch adds SSL support. It gives an indication in the README of how to set up SSL, as well as how to get ACME certs using Certbot. This patch also implements automatic port selection when the port field is ommitted in the configuration.

Signed-off-by: Amy Parker <amy@amyip.net>