### PR TITLE
db: use bigints

### DIFF
--- a/installer/db-setup-mysql.sql
+++ b/installer/db-setup-mysql.sql
@@ -26,4 +26,4 @@ use ssvp;
 create table ssvp_day_logs (logDate date not null, serverName text not null, serverStatus integer not null);
 create table ssvp_interval_logs (logDate datetime not null, serverName text not null, serverStatus boolean not null);
 create table ssvp_cached_stats (monthlyUptime double not null, yearlyUptime double not null, allTimeUptime double not null, serverName text not null, currentStatus integer not null);
-create table ssvp_events (eventID integer not null auto_increment, serverName text not null, eventName text not null, eventDescription text, startTime datetime not null, endTime datetime, severity integer not null, primary key (eventID);
+create table ssvp_events (eventID serial, serverName text not null, eventName text not null, eventDescription text, startTime datetime not null, endTime datetime, severity integer not null, primary key (eventID);

--- a/installer/db-setup-postgres.sql
+++ b/installer/db-setup-postgres.sql
@@ -28,4 +28,4 @@ grant all on all tables in schema public to ssvp;
 create table ssvp_day_logs (logDate date not null, serverName text not null, serverStatus integer not null);
 create table ssvp_interval_logs (logDate timestamp not null, serverName text not null, serverStatus boolean not null);
 create table ssvp_cached_stats (monthlyUptime double precision not null, yearlyUptime double precision not null, allTimeUptime double precision not null, serverName text not null, currentStatus integer not null);
-create table ssvp_events (eventID serial primary key not null, serverName text not null, eventName text not null, eventDescription text, startTime timestamp not null, endTime timestamp, severity integer not null);
+create table ssvp_events (eventID serial primary key, serverName text not null, eventName text not null, eventDescription text, startTime timestamp not null, endTime timestamp, severity integer not null);


### PR DESCRIPTION
This patch switches MySQL to use the `serial` datatype, which is an unsigned long integer that implements most necessary things. PostgreSQL also had its "not null" tag removed, as it is implied through its usage of `serial`.

Signed-off-by: Amy Parker <amy@amyip.net>